### PR TITLE
Fix for Timepoint to Timepoint logic when 2nd point is before 1st point

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 ## Project Goal
 To create a web version of a time calculator app which can eventually be ported to mobile.
 
-See the following [freehand](https://illys596617.invisionapp.com/freehand/Time-Calculator-Brainstorming-2W6bo0eSw) for planning notes.
-
 ## Screenshot
 
 ![image](https://user-images.githubusercontent.com/17151160/142777740-8ccc0bd6-8e56-4a38-a821-9dc218487e71.png)

--- a/src/timeUtils/time-math.test.ts
+++ b/src/timeUtils/time-math.test.ts
@@ -40,7 +40,7 @@ describe('TimeMath.evaluate', () => {
     expect(actual?.type).toBe(TimeType.DURATION);
   });
 
-  it('can evalluate a duration minus duration operation', () => {
+  it('can evaluate a duration minus duration operation', () => {
     const parsedOperation = timeParser.parseExpression(convertStrToTokens('1hr30min - 45min'));
     const actual = parsedOperation && TimeMath.evaluate(parsedOperation);
     const expected = (HOUR + (30 * MINUTE)) - (45 * MINUTE);
@@ -56,10 +56,10 @@ describe('TimeMath.evaluate', () => {
     expect(actual?.type).toBe(TimeType.DURATION);
   });
 
-  it('can evaluate a timepoint to an earlier timepoint', () => {
+  it('if the second timepoint is before the first timepoint evaluates the time to that timepoint on the next day', () => {
     const parsedOperation = timeParser.parseExpression(convertStrToTokens('5:00pm to 4:30pm'));
     const actual = parsedOperation && TimeMath.evaluate(parsedOperation);
-    const expected = -1 * 30 * MINUTE;
+    const expected = 23 * HOUR + 30 * MINUTE;
     expect(actual?.value).toBe(expected);
     expect(actual?.type).toBe(TimeType.DURATION);
   });

--- a/src/timeUtils/time-math.ts
+++ b/src/timeUtils/time-math.ts
@@ -1,4 +1,4 @@
-import { ParsedOperation, ParsedExpression, OperationType, TimeOperator, TimeType, Time } from './time-parser';
+import { ParsedOperation, ParsedExpression, OperationType, TimeOperator, TimeType, Time, HOUR } from './time-parser';
 
 export class TimeMath {
   static evaluate(operation: ParsedOperation): Time | null {
@@ -58,6 +58,11 @@ export class TimeMath {
   static evaluatePointToPoint(expression: ParsedExpression): number | null {
     const [value1, operator, value2] = expression;
     if (operator !== TimeOperator.TO) return null;
-    return value2.value - value1.value;
+    if (value2.value >= value1.value) {
+      return value2.value - value1.value;
+    }
+    // if time 2 is earlier than time 1 assume calculating to that time the next day
+    // ie 11:00pm to 1:00am = 2hrs NOT -22hrs
+    return (24 * HOUR + value2.value) - value1.value;
   }
 }


### PR DESCRIPTION
Fixes issue where when calculating pointA to pointB if pointB is earlier than pointA a negative number is returned.

A more useful calculations would be pointA to pointB the next day. 

Ex: 11:00pm to 1:00am = 2hrs - this is much more useful than knowing that 1:00am is -22hrs before 11:00pm on the same day.