### PR TITLE
Updates to back button - replace "<" with triangle symbol

### DIFF
--- a/src/components/ButtonGrid/ButtonGrid.tsx
+++ b/src/components/ButtonGrid/ButtonGrid.tsx
@@ -123,7 +123,7 @@ const ButtonsArray: ButtonConfig[] = [
     }
   },
   {
-    displayString: '<',
+    displayString: 'C',
     color: buttonColor.CANCEL,
     callback: ({ removeInput, clearInput, outputValue }) => {
       if (outputValue.length) {
@@ -144,17 +144,18 @@ const ButtonsArray: ButtonConfig[] = [
 ];
 
 export const ButtonGrid: React.FC<Props> = (props) => {
-  const formatBackButton = (btnDisplayString: string): string => {
-    if (btnDisplayString !== '<') {
-      return btnDisplayString;
-    }
-
-    return props.outputValue.length ? 'C' : '<';
-  } 
-
   return <ButtonGridWrapper>
     {ButtonsArray.map((btnConfig: ButtonConfig) => {
-      return <Button key={btnConfig.displayString} color={btnConfig.color} onClick={() => btnConfig.callback(props)}>{formatBackButton(btnConfig.displayString)}</Button>
+      if (btnConfig.displayString !== 'C') {
+        return <Button key={btnConfig.displayString} color={btnConfig.color} onClick={() => btnConfig.callback(props)}>{btnConfig.displayString}</Button>
+      } else {
+        return (
+          <BackButton key={btnConfig.displayString} color={btnConfig.color} onClick={() => btnConfig.callback(props)}>
+            {props.outputValue.length ? btnConfig.displayString : <BackSymbol></BackSymbol>}
+          </BackButton>
+        )
+      }
+      
     })}
   </ButtonGridWrapper>
 }
@@ -179,4 +180,19 @@ const Button = styled.button`
   &:hover {
     cursor: pointer;
   }
+`;
+
+const BackButton = styled(Button)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const BackSymbol = styled.div`
+  width: 0; 
+  height: 0; 
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent; 
+  border-right: 24px solid ${btnColors.BTN_TEXT_ACTIVE};
+  margin-right: 4px;
 `;

--- a/src/components/button-colors.ts
+++ b/src/components/button-colors.ts
@@ -7,5 +7,5 @@ export const BTN_YELLOW = '#f2c84c';
 export const BTN_BLUE = '#56cbf2';
 
 export const BTN_TEXT_INACTIVE = '#bdbdbd';
-export const BTN_TEXT_ACTIVE = '#000000';
+export const BTN_TEXT_ACTIVE = '#313131';
 export const BTN_INACTIVE = '#f1f1f1';


### PR DESCRIPTION
This PR implements a minor refactor of the back button code. The "<" character has been replaced with a proper triangle symbol (using CSS). 

The active button text color has also been updated from #000000 to a dark gray.